### PR TITLE
Fix syntax of stryker.conf.js in quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ module.exports = function(config){
   config.set({
     files: ['test/helpers/**/*.js', 
             'test/unit/**/*.js', 
-            { pattern: 'src/**/*.js', included: false, mutated: true }
-            { pattern: 'src/templates/*.html', included: false, mutated: false }
+            { pattern: 'src/**/*.js', included: false, mutated: true },
+            { pattern: 'src/templates/*.html', included: false, mutated: false },
             '!src/fileToIgnore.js'],
     testFramework: 'mocha',
     testRunner: 'mocha',


### PR DESCRIPTION
Commas were missing in stryker.conf.js in the readme.md
Note: The same syntax issues are present in 
https://stryker-mutator.github.io/quickstart.html but wasn't able to fix it.